### PR TITLE
hardening/28_do_not_run_as_sudo

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - [cosmos] [HARDENING] Add initial content to the general README (#1)
 - [cosmos-gui] [HARDENING] Set 740 permissions to new created accounts (#17)
 - [cosmos-gui] [HARDENING] Add the HDFS superuser as a configuration parameter (#20)
+- [cosmos-gui] [HARDENING] Running as sudo is not required anymore (#28)

--- a/cosmos-gui/package.json
+++ b/cosmos-gui/package.json
@@ -15,6 +15,6 @@
     "express-boom": "^0.3.0"
   },
   "scripts": {
-    "start": "sudo node ./src/app.js"
+    "start": "node ./src/app.js"
   }
 }


### PR DESCRIPTION
* Implements issue #28 
* No unit tests nor e2e tests are required.
* Assignee @gtorodelvalle 

**IMPORTANT NOTES**:

* Do not merge until PR https://github.com/telefonicaid/fiware-cosmos/pull/24 has been merged.
* Within that PR the REAME section about the `cosmos-gui` user creation as been modified, explaining it is a normal user and not a sudoer. Thus, no documentation modifications are required within this PR.