### PR TITLE
hardening/109_conn_pool_cosmos_gui

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,5 @@
 - [doc] [BUG] Wrong link fixed in the documentation (#98)
 - [cosmos-auth] [HARDENING] Document how to create a self-signed certificate (#99)
 - [cosmos-gui] [HARDENING] Add an annex about binding applications to ports under 1024 (#103)
+- [cosmos-gui] [HARDENING] Use a pool of MySQL connections instead of a single permanent one (#109)
+

--- a/cosmos-gui/src/app.js
+++ b/cosmos-gui/src/app.js
@@ -207,14 +207,6 @@ app.get('/logout', function(req, res){
     res.redirect('/');
 });
 
-// Create a permanent connection to MySQL, and start the server
-mysqlDriver.connect(function(error, result) {
-    if (error) {
-        logger.error('There was some error when connecting to MySQL database. The server will not be run. ' +
-            'Details: ' + error);
-    } else {
-        // Start the application, listening at the configured port
-        logger.info("cosmos-gui running at http://localhost:" + port);
-        https.createServer(httpsOptions, app).listen(port);
-    } // if else
-});
+// Start the application, listening at the configured port
+logger.info("cosmos-gui running at https://localhost:" + port);
+https.createServer(httpsOptions, app).listen(port);

--- a/cosmos-gui/src/mysql_driver.js
+++ b/cosmos-gui/src/mysql_driver.js
@@ -28,8 +28,8 @@ var mysql = require('mysql');
 var mysqlConfig = require('../conf/cosmos-gui.json').mysql;
 var logger = require('./logger.js');
 
-// Create a connection to the database
-var connection = mysql.createConnection({
+// Create a pool of connections to the database
+var pool = mysql.createPool({
     host: mysqlConfig.host,
     port: mysqlConfig.port,
     user: mysqlConfig.user,
@@ -37,89 +37,99 @@ var connection = mysql.createConnection({
     database: mysqlConfig.database
 });
 
-function connect(callback) {
-    connection.connect(function (error) {
+function addUser(idm_username, username, password, hdfsQuota, callback) {
+    pool.getConnection(function(error, connection) {
         if (error) {
             callback(error);
         } else {
-            logger.info('Connected to http://' + mysqlConfig.host + ':' + mysqlConfig.port + '/' +
-                mysqlConfig.database);
-            callback(null);
+            var query = connection.query(
+                'INSERT INTO cosmos_user (idm_username, username, password, hdfs_quota) ' +
+                'VALUES (?, ?, ?, ?)',
+                [idm_username, username, password, hdfsQuota],
+                function (error, result) {
+                    if (error) {
+                        callback(error)
+                    } else {
+                        logger.info('Successful insert: \'INSERT INTO cosmos_user ' +
+                            '(idm_username, username, password, hdfs_quota) VALUES ' +
+                            '(' + idm_username + ', ' + username + ', ' + password + ', ' + hdfsQuota + ')\'');
+                        connection.release();
+                        callback(null, result);
+                    } // if else
+                }
+            );
         } // if else
     });
-} // connect
-
-function addUser(idm_username, username, password, hdfsQuota, callback) {
-    var query = connection.query(
-        'INSERT INTO cosmos_user (idm_username, username, password, hdfs_quota) ' +
-        'VALUES (?, ?, ?, ?)',
-        [idm_username, username, password, hdfsQuota],
-        function (error, result) {
-            if (error) {
-                callback(error)
-            } else {
-                logger.info('Successful insert: \'INSERT INTO cosmos_user ' +
-                    '(idm_username, username, password, hdfs_quota) VALUES ' +
-                    '(' + idm_username + ', ' + username + ', ' + password + ', ' + hdfsQuota + ')\'');
-                callback(null, result);
-            } // if else
-        }
-    );
 } // addUser
 
 function addPassword(idm_username, password, callback) {
-    var query = connection.query(
-        'UPDATE cosmos_user SET password=\'' + password + '\' WHERE idm_username=\'' + idm_username + '\'',
-        function(error, result) {
-            if (error) {
-                callback(error);
-            } else {
-                logger.info('Successful update: \'UPDATE cosmos_user SET password=\'' + password +
-                    '\' WHERE idm_username=\'' + idm_username + '\'');
-                callback(null, result);
-            } // if else
-        }
-    );
+    pool.getConnection(function(error, connection) {
+        if (error) {
+            callback(error);
+        } else {
+            var query = connection.query(
+                'UPDATE cosmos_user SET password=\'' + password + '\' WHERE idm_username=\'' + idm_username + '\'',
+                function (error, result) {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        logger.info('Successful update: \'UPDATE cosmos_user SET password=\'' + password +
+                            '\' WHERE idm_username=\'' + idm_username + '\'');
+                        connection.release();
+                        callback(null, result);
+                    } // if else
+                }
+            );
+        } // if else
+    });
 } // addPassword
 
 function getUser(idm_username, callback) {
-    var query = connection.query(
-        'SELECT * from cosmos_user WHERE idm_username=\'' + idm_username + '\'',
-        function (error, result) {
-            if (error) {
-                callback(error);
-            } else {
-                logger.info('Successful select: \'SELECT * from cosmos_user WHERE idm_username=\'' +
-                    idm_username + '\'');
-                callback(null, result);
-            } // if else
-        }
-    );
+    pool.getConnection(function(error, connection) {
+        if (error) {
+            callback(error);
+        } else {
+            var query = connection.query(
+                'SELECT * from cosmos_user WHERE idm_username=\'' + idm_username + '\'',
+                function (error, result) {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        logger.info('Successful select: \'SELECT * from cosmos_user WHERE idm_username=\'' +
+                            idm_username + '\'');
+                        connection.release();
+                        callback(null, result);
+                    } // if else
+                }
+            );
+        } // if else
+    });
 } // getUser
 
 function getUserByCosmosUser(username, callback) {
-    var query = connection.query(
-        'SELECT * from cosmos_user WHERE username=\'' + username + '\'',
-        function (error, result) {
-            if (error) {
-                callback(error);
-            } else {
-                logger.info('Successful select: \'SELECT * from cosmos_user WHERE username=\'' + username + '\'');
-                callback(null, result);
-            } // if else
-        }
-    );
+    pool.getConnection(function(error, connection) {
+        if (error) {
+            callback(error);
+        } else {
+            var query = connection.query(
+                'SELECT * from cosmos_user WHERE username=\'' + username + '\'',
+                function (error, result) {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        logger.info('Successful select: \'SELECT * from cosmos_user WHERE username=\'' + username + '\'');
+                        connection.release();
+                        callback(null, result);
+                    } // if else
+                }
+            );
+        } // if else
+    });
 } // getUserByCosmosUser
 
-function close(connection) {
-    connection.end();
-} // close
-
 module.exports = {
-    connect: connect,
     addUser: addUser,
     addPassword: addPassword,
     getUser: getUser,
-    getUserByCosmosUser: getUserByCosmosUser,
-    close: close
+    getUserByCosmosUser: getUserByCosmosUser
 } // module.exports

--- a/cosmos-gui/src/mysql_driver.js
+++ b/cosmos-gui/src/mysql_driver.js
@@ -40,7 +40,9 @@ var pool = mysql.createPool({
 function addUser(idm_username, username, password, hdfsQuota, callback) {
     pool.getConnection(function(error, connection) {
         if (error) {
-            callback(error);
+            if (callback) {
+                callback(error);
+            } // if
         } else {
             var query = connection.query(
                 'INSERT INTO cosmos_user (idm_username, username, password, hdfs_quota) ' +
@@ -48,13 +50,18 @@ function addUser(idm_username, username, password, hdfsQuota, callback) {
                 [idm_username, username, password, hdfsQuota],
                 function (error, result) {
                     if (error) {
-                        callback(error)
+                        if (callback) {
+                            callback(error);
+                        } // if
                     } else {
                         logger.info('Successful insert: \'INSERT INTO cosmos_user ' +
                             '(idm_username, username, password, hdfs_quota) VALUES ' +
                             '(' + idm_username + ', ' + username + ', ' + password + ', ' + hdfsQuota + ')\'');
                         connection.release();
-                        callback(null, result);
+
+                        if (callback) {
+                            callback(null, result);
+                        } // if
                     } // if else
                 }
             );
@@ -65,18 +72,25 @@ function addUser(idm_username, username, password, hdfsQuota, callback) {
 function addPassword(idm_username, password, callback) {
     pool.getConnection(function(error, connection) {
         if (error) {
-            callback(error);
+            if (callback) {
+                callback(error);
+            } // if
         } else {
             var query = connection.query(
                 'UPDATE cosmos_user SET password=\'' + password + '\' WHERE idm_username=\'' + idm_username + '\'',
                 function (error, result) {
                     if (error) {
-                        callback(error);
+                        if (callback) {
+                            callback(error);
+                        } // if
                     } else {
                         logger.info('Successful update: \'UPDATE cosmos_user SET password=\'' + password +
                             '\' WHERE idm_username=\'' + idm_username + '\'');
                         connection.release();
-                        callback(null, result);
+
+                        if (callback) {
+                            callback(null, result);
+                        } // if
                     } // if else
                 }
             );
@@ -87,18 +101,25 @@ function addPassword(idm_username, password, callback) {
 function getUser(idm_username, callback) {
     pool.getConnection(function(error, connection) {
         if (error) {
-            callback(error);
+            if (callback) {
+                callback(error);
+            } // if
         } else {
             var query = connection.query(
                 'SELECT * from cosmos_user WHERE idm_username=\'' + idm_username + '\'',
                 function (error, result) {
                     if (error) {
-                        callback(error);
+                        if (callback) {
+                            callback(error);
+                        } // if
                     } else {
                         logger.info('Successful select: \'SELECT * from cosmos_user WHERE idm_username=\'' +
                             idm_username + '\'');
                         connection.release();
-                        callback(null, result);
+
+                        if (callback) {
+                            callback(null, result);
+                        } // if
                     } // if else
                 }
             );
@@ -109,17 +130,24 @@ function getUser(idm_username, callback) {
 function getUserByCosmosUser(username, callback) {
     pool.getConnection(function(error, connection) {
         if (error) {
-            callback(error);
+            if (callback) {
+                callback(error);
+            } // if
         } else {
             var query = connection.query(
                 'SELECT * from cosmos_user WHERE username=\'' + username + '\'',
                 function (error, result) {
                     if (error) {
-                        callback(error);
+                        if (callback) {
+                            callback(error);
+                        } // if
                     } else {
                         logger.info('Successful select: \'SELECT * from cosmos_user WHERE username=\'' + username + '\'');
                         connection.release();
-                        callback(null, result);
+
+                        if (callback) {
+                            callback(null, result);
+                        } // if
                     } // if else
                 }
             );

--- a/cosmos-gui/test/node/mysql_driver_test.js
+++ b/cosmos-gui/test/node/mysql_driver_test.js
@@ -61,14 +61,6 @@ var connectionMock = {
 mysqlDriver.__set__('connection', connectionMock);
 
 // Tests suite
-describe('[mysqlDriver.connect] create a MySQL connection', function() {
-    it('should return null error', function () {
-        mysqlDriver.connect(function(error) {
-            assert.equal(null, error);
-        });
-    });
-});
-
 describe('[mysqlDriver.addUser] add a new user', function() {
     it('should return null error and an empty result set', function() {
         mysqlDriver.addUser(idm_username, username, password, hdfsQuota, function(error, result) {
@@ -102,11 +94,5 @@ describe('[mysqlDriver.getUserByCosmosUser] get a user by the cosmos user', func
             assert.equal(null, error);
             assert.equal(username, result[0]);
         });
-    });
-});
-
-describe('[mysqlDriver.close] close a connection', function() {
-    it('should finish', function() {
-        mysqlDriver.close(connectionMock);
     });
 });


### PR DESCRIPTION
* Implements issue #109 
* 100% unit tests passed:
```
***** STARTING TESTS *****

  ․ [appUtils.buildUsername] build a username from a valid base string should return frb1 when frb is used as base string: 0ms
    [appUtils.buildUsername] build an invalid username from an invalid base string should return null when fiware is used as base string: error: The base username "fiware" is not allowed
  ․ [appUtils.buildUsername] build an invalid username from an invalid base string should return null when fiware is used as base string: 3ms
    [appUtils.provisionCluster] provision a cluster should redirect to /after when being called from /before: info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo useradd frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 12345 | sudo passwd frb --stdin | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -mkdir /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -chown -R frb:frb /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -chmod -R 740 /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop dfsadmin -setSpaceQuota 5g /user/frb' | sudo bash"'
  ․ [appUtils.provisionCluster] provision a cluster should redirect to /after when being called from /before: 2ms

  3 passing (11ms)


  ․ [mysqlDriver.addUser] add a new user should return null error and an empty result set: 4ms
  ․ [mysqlDriver.addPassword] add a new password should return null error and an empty result set: 1ms
  ․ [mysqlDriver.getUser] get a user by the idm user should return null error and a result set containing frb1: 1ms
  ․ [mysqlDriver.getUserByCosmosUser] get a user by the cosmos user should return null error and a result set containing frb1: 0ms

  4 passing (19ms)

****** TESTS ENDED *******
```
* (unofficial) e2e tests passed in FIWARE Lab:
```
info: Successful select: 'SELECT * from cosmos_user WHERE username='soyunpaquete'
info: Successful insert: 'INSERT INTO cosmos_user (idm_username, username, password, hdfs_quota, registration_time) VALUES (soyunpaquete@XXXXXXXX, soyunpaquete, XXXXXXXXX, 5, 2015-10-09 06:50:21.236)'
info: Successful information added to the database for user soyunpaquete
```
* Assignee @gtorodelvalle 