### PR TITLE
bug/117_check_access_token_not_sent

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -7,3 +7,4 @@
 - [cosmos-gui] [HARDENING] Use a pool of MySQL connections instead of a single permanent one (#109)
 - [cosmos-gui] [FEATURE] Add a user profile view (#112)
 - [general] ADD LICENSE and Contribution Policy (#114)
+- [cosmos-gui] [BUG] Prevent the GUI crashes when no access_token is sent by the IdM (#117)

--- a/cosmos-gui/src/app.js
+++ b/cosmos-gui/src/app.js
@@ -143,10 +143,14 @@ app.get('/login', function(req, res) {
 // Handles requests from IDM with the access code
 app.get('/auth', function(req, res) {
     // Using the access code goes again to the IDM to obtain the access_token
-    oa.getOAuthAccessToken(req.query.code, function (e, results){
-    // Stores the access_token in a session cookie
-        req.session.access_token = results.access_token;
-        res.redirect('/');
+    oa.getOAuthAccessToken(req.query.code, function (e, results) {
+        if ('access_token' in results) {
+            // Stores the access_token in a session cookie
+            req.session.access_token = results.access_token;
+            res.redirect('/');
+        } else {
+            res.redirect('/');
+        } // if else
     });
 });
 

--- a/cosmos-gui/src/app.js
+++ b/cosmos-gui/src/app.js
@@ -147,10 +147,9 @@ app.get('/auth', function(req, res) {
         if ('access_token' in results) {
             // Stores the access_token in a session cookie
             req.session.access_token = results.access_token;
-            res.redirect('/');
-        } else {
-            res.redirect('/');
-        } // if else
+        } // if
+
+        res.redirect('/');
     });
 });
 


### PR DESCRIPTION
* Fixes issue #117 
* 100% tests passed:
```
***** STARTING TESTS *****

  ․ [appUtils.buildUsername] build a username from a valid base string should return frb1 when frb is used as base string: 1ms
    [appUtils.buildUsername] build an invalid username from an invalid base string should return null when fiware is used as base string: error: The base username "fiware" is not allowed
  ․ [appUtils.buildUsername] build an invalid username from an invalid base string should return null when fiware is used as base string: 3ms
    [appUtils.provisionCluster] provision a cluster should redirect to /after when being called from /before: info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo useradd frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 12345 | sudo passwd frb --stdin | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -mkdir /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -chown -R frb:frb /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -chmod -R 740 /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop dfsadmin -setSpaceQuota 5g /user/frb' | sudo bash"'
  ․ [appUtils.provisionCluster] provision a cluster should redirect to /after when being called from /before: 2ms

  3 passing (9ms)


  ․ [mysqlDriver.addUser] add a new user should return null error and an empty result set: 5ms
  ․ [mysqlDriver.addPassword] add a new password should return null error and an empty result set: 1ms
  ․ [mysqlDriver.getUser] get a user by the idm user should return null error and a result set containing frb1: 1ms
  ․ [mysqlDriver.getUserByCosmosUser] get a user by the cosmos user should return null error and a result set containing frb1: 0ms

  4 passing (20ms)

****** TESTS ENDED *******
```
* (unofficial) e2e tests passed in FIWARE Lab
* Assignee @gtorodelvalle 