### PR TITLE
bug/122_check_built_username

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,4 +6,5 @@
 - [cosmos-gui] [HARDENING] Force the usage of TLSv1 instead of SSLv3 (#106)
 - [cosmos-gui] [HARDENING] Use a pool of MySQL connections instead of a single permanent one (#109)
 - [cosmos-gui] [FEATURE] Add a user profile view (#112)
-- [general] ADD LICENSE and Contribution Policy (#114)
+- [general] [HARDENING] ADD LICENSE and Contribution Policy (#114)
+- [cosmos-gui] [BUG] Check the built username is about an invalid username (i.e. null) (#122)

--- a/cosmos-gui/src/app.js
+++ b/cosmos-gui/src/app.js
@@ -157,7 +157,7 @@ app.post('/new_account', function(req, res) {
         var password1 = req.body.password1;
         var password2 = req.body.password2;
 
-        if (password1 === password2) {
+        if ((password1 === password2) && (username != null)) {
             mysqlDriver.addUser(idm_username, username, password1, hdfsQuota, function(error, result) {
                 if (error) {
                     var boomError = boom.badData('There was some error when adding information in the database for user '+ username, error);


### PR DESCRIPTION
* Fixed issue #122 
* 100% unit tests passed:
```
***** STARTING TESTS *****

  ․ [appUtils.buildUsername] build a username from a valid base string should return frb1 when frb is used as base string: 0ms
    [appUtils.buildUsername] build an invalid username from an invalid base string should return null when fiware is used as base string: error: The base username "fiware" is not allowed
  ․ [appUtils.buildUsername] build an invalid username from an invalid base string should return null when fiware is used as base string: 3ms
    [appUtils.provisionCluster] provision a cluster should redirect to /after when being called from /before: info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo useradd frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 12345 | sudo passwd frb --stdin | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -mkdir /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -chown -R frb:frb /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop fs -chmod -R 740 /user/frb' | sudo bash"'
info: Successful command executed: 'ssh -tt -i ./priv_key admin@fake.cosmos.lab.fiware.org "echo 'sudo -u hdfs hadoop dfsadmin -setSpaceQuota 5g /user/frb' | sudo bash"'
  ․ [appUtils.provisionCluster] provision a cluster should redirect to /after when being called from /before: 2ms

  3 passing (11ms)


  ․ [mysqlDriver.addUser] add a new user should return null error and an empty result set: 4ms
  ․ [mysqlDriver.addPassword] add a new password should return null error and an empty result set: 1ms
  ․ [mysqlDriver.getUser] get a user by the idm user should return null error and a result set containing frb1: 0ms
  ․ [mysqlDriver.getUserByCosmosUser] get a user by the cosmos user should return null error and a result set containing frb1: 0ms

  4 passing (20ms)

****** TESTS ENDED *******
```
* (unofficial) e2e tests passed in FIWARE Lab
* Assignee @gtorodelvalle 