### PR TITLE
bug/207_restrict_access_to_accounts_made_by_prefixes

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,4 @@
 - [cosmos-tidoop-apo][feature] Return stderr and stdout when retrieving jobs info (#200)
 - [cosmos-proxy][doc] Update apiary file and documentation about cosmos-proxy installation and configuration (#204)
 - [cosmos-proxy][hardening] Add certaing base paths restrictions in cosmos-proxy (#206)
+- [cosmos-proxy][bug] Add an access restriction to accounts made by prefixes of original users (#207)

--- a/cosmos-proxy/src/cosmos-proxy.js
+++ b/cosmos-proxy/src/cosmos-proxy.js
@@ -82,8 +82,6 @@ function isAuthorized(username, path) {
         if (username === conf.superuser) {
             return true;
         } else {
-            logger.info('/webhdfs/v1/user/' + username);
-            logger.info('/webhdfs/v1/user/' + username + '/');
             return (path === '/webhdfs/v1/user/' + username
                 || path.indexOf('/webhdfs/v1/user/' + username + '/') === 0);
         } // if else

--- a/cosmos-proxy/src/cosmos-proxy.js
+++ b/cosmos-proxy/src/cosmos-proxy.js
@@ -82,7 +82,10 @@ function isAuthorized(username, path) {
         if (username === conf.superuser) {
             return true;
         } else {
-            return (path.indexOf('/webhdfs/v1/user/' + username) === 0);
+            logger.info('/webhdfs/v1/user/' + username);
+            logger.info('/webhdfs/v1/user/' + username + '/');
+            return (path === '/webhdfs/v1/user/' + username
+                || path.indexOf('/webhdfs/v1/user/' + username + '/') === 0);
         } // if else
     } // if else if
 } // isAuthorized


### PR DESCRIPTION
* Fix issue #207 
* No tests are required.
* e2e (unofficial) tests passed. `pcoello25` accessing to `/webhdfs/v1/user/pcoello25654`:
```
$ curl -X GET "http://localhost:14000/webhdfs/v1/user/pcoello25654?op=liststatus&user.name=pcoello25" -H "X-Auth-Token: xxxxxxxxxxxxxxx"
Authorization error: user pcoello25 cannot access /webhdfs/v1/user/pcoello25654

info: pcoello25 is trying to access to /webhdfs/v1/user/pcoello25654 with the token xxxxxxxxxxxxxxx
error: Authorization error: user pcoello25 is not allowed to access /webhdfs/v1/user/pcoello25654
```
* Assignee: @frbattid 