### PR TITLE
hardening/227_improve_hive_auth_provider_logs

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- [cosmos-hive-auth-provider][hardening] Improve logs (#227)

--- a/cosmos-hive-auth-provider/src/main/java/com/telefonica/iot/cosmos/hive/authprovider/OAuth2AuthenticationProviderImpl.java
+++ b/cosmos-hive-auth-provider/src/main/java/com/telefonica/iot/cosmos/hive/authprovider/OAuth2AuthenticationProviderImpl.java
@@ -47,24 +47,26 @@ public class OAuth2AuthenticationProviderImpl implements PasswdAuthenticationPro
      * Constructor.
      */
     public OAuth2AuthenticationProviderImpl() {
-        // get the cnfigured Identity Manager endpoint
+        // Get the configured Identity Manager endpoint
         HiveConf conf = null;
         
         try {
             conf = new HiveConf();
+            LOGGER.info("Hive configuration read");
         } catch (Exception e) {
             LOGGER.info("Unable to read the Hive configuration, using default values");
         } finally {
             if (conf == null) {
                 idmEndpoint = "https://account.lab.fiware.org";
+                LOGGER.info("Using hardcoded Identity Manager endpoint: https://account.lab.fiware.org");
             } else {
                 idmEndpoint = conf.get("com.telefonica.iot.idm.endpoint", "https://account.lab.fiware.org");
+                LOGGER.info("Using configured Identity Manager endpoint: " + idmEndpoint);
             } // if else
             
-            LOGGER.info("Identity Manager endpoint: " + idmEndpoint);
         } // try catch finally
         
-        // create a factory of Http clients
+        // Create a factory of Http clients
         if (idmEndpoint.startsWith("https")) {
             httpClientFactory = new HttpClientFactory(true);
         } else {

--- a/cosmos-hive-auth-provider/src/main/java/com/telefonica/iot/cosmos/hive/authprovider/OAuth2AuthenticationProviderImpl.java
+++ b/cosmos-hive-auth-provider/src/main/java/com/telefonica/iot/cosmos/hive/authprovider/OAuth2AuthenticationProviderImpl.java
@@ -54,16 +54,21 @@ public class OAuth2AuthenticationProviderImpl implements PasswdAuthenticationPro
             conf = new HiveConf();
             LOGGER.info("Hive configuration read");
         } catch (Exception e) {
-            LOGGER.info("Unable to read the Hive configuration, using default values");
+            LOGGER.debug("Unable to read the Hive configuration, using default values");
         } finally {
             if (conf == null) {
                 idmEndpoint = "https://account.lab.fiware.org";
-                LOGGER.info("Using hardcoded Identity Manager endpoint: https://account.lab.fiware.org");
+                LOGGER.debug("Using hardcoded Identity Manager endpoint: https://account.lab.fiware.org");
             } else {
                 idmEndpoint = conf.get("com.telefonica.iot.idm.endpoint", "https://account.lab.fiware.org");
-                LOGGER.info("Using configured Identity Manager endpoint: " + idmEndpoint);
+                LOGGER.debug("com.telefonica.iot.idm.endpoint=" + idmEndpoint);
+                LOGGER.debug("hive.server2.enable.doAs=" + conf.get("hive.server2.enable.doAs"));
+                LOGGER.debug("hive.server2.authentication=" + conf.get("hive.server2.authentication"));
+                LOGGER.debug("hive.server2.custom.authentication.class="
+                        + conf.get("hive.server2.custom.authentication.class"));
+                LOGGER.debug("hadoop.proxyuser.hive.groups=" + conf.get("hadoop.proxyuser.hive.groups"));
+                LOGGER.debug("hadoop.proxyuser.hive.hosts=" + conf.get("hadoop.proxyuser.hive.hosts"));
             } // if else
-            
         } // try catch finally
         
         // Create a factory of Http clients


### PR DESCRIPTION
* Implements issue #227
* e2e tests:

```
17/03/01 10:04:18 DEBUG authprovider.HttpClientFactory: com.telefonica.iot.idm.endpoint=https://account.lab.fiware.org
17/03/01 10:04:18 DEBUG authprovider.HttpClientFactory: hive.server2.enable.doAs=true
17/03/01 10:04:18 DEBUG authprovider.HttpClientFactory: hive.server2.authentication=CUSTOM
17/03/01 10:04:18 DEBUG authprovider.HttpClientFactory: hive.server2.custom.authentication.class=com.telefonica.iot.cosmos.hive.authprovider.OAuth2AuthenticationProviderImpl
17/03/01 10:04:18 DEBUG authprovider.HttpClientFactory: hadoop.proxyuser.hive.groups=*
17/03/01 10:04:18 DEBUG authprovider.HttpClientFactory: hadoop.proxyuser.hive.hosts=*
```