### PR TITLE
Update api package

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,4 @@
 - [cosmos-hive-auth-provider][hardening] Improve logs (#227)
 - [cosmos-hive-auth-provider][feature] Add OAuth2 cache (#225)
+- [cosmos-auth][vulnerability] Upgrade hapi to 11.1.3 
+- [cosmos-tidoop-api][vulnerability] Upgrade hapi to 11.1.3 

--- a/cosmos-auth/package.json
+++ b/cosmos-auth/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/telefonicaid/fiware-cosmos.git"
   },
   "dependencies": {
-    "hapi": "^8.5.1",
+    "hapi": "~11.1.3",
     "boom": "^2.8.0",
     "winston": "^1.0.1"
   },

--- a/cosmos-tidoop-api/package.json
+++ b/cosmos-tidoop-api/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/telefonicaid/fiware-cosmos.git"
   },
   "dependencies": {
-    "hapi": "^8.5.1",
+    "hapi": "~11.1.3",
     "winston": "^1.0.1"
   },
   "scripts": {


### PR DESCRIPTION
This is due a vulnerability alert send by github.com. It mimics the same changes that we have recently done in STH repo (see PR https://github.com/telefonicaid/fiware-sth-comet/pull/444). We understand that if the change hasn't raise travis errors in STH repo, then the new version is backward compabitle with the older (even when there is a +3 in mayor version number...).